### PR TITLE
Fix Laravel VSCode Extension Error

### DIFF
--- a/src/Enums/Transport.php
+++ b/src/Enums/Transport.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Prism\Relay\Enums;
 
-enum Transport
+enum Transport: string
 {
-    case Http;
-    case Stdio;
+    case Http = 'http';
+    case Stdio = 'stdio';
 }


### PR DESCRIPTION
## Description

The transport enum didn't have backing values so would cause the Laravel VSCode extension to error when it attempted to serialize an apps config values.

Fixes #14 

## Breaking Changes

I don't believe this breaks anything I can't imagine a change like this would but I haven't checked the codebase and I just forked/edited/commited/PR'd in my web browser so haven't run tests.

