### PR TITLE
feat: pass runtime environment

### DIFF
--- a/src/Facades/Relay.php
+++ b/src/Facades/Relay.php
@@ -9,8 +9,8 @@ use Prism\Prism\Tool;
 use Prism\Relay\RelayFactory;
 
 /**
- * @method static RelayFactory make(string $serverName)
- * @method static array<int, Tool> tools(string $serverName)
+ * @method static RelayFactory make(string $serverName, array $environment = [])
+ * @method static array<int, Tool> tools(string $serverName, array $environment = [])
  *
  * @see RelayFactory
  */

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -23,11 +23,13 @@ class Relay
     protected Transport $transport;
 
     /**
+     * @param  array<string, mixed>  $environment
+     *
      * @throws ServerConfigurationException
      */
-    public function __construct(protected string $serverName)
+    public function __construct(protected string $serverName, array $environment = [])
     {
-        $this->resolveServerConfig();
+        $this->resolveServerConfig($environment);
         $this->initializeTransport();
     }
 
@@ -509,9 +511,11 @@ class Relay
     }
 
     /**
+     * @param  array<string, mixed>  $environment
+     *
      * @throws ServerConfigurationException
      */
-    protected function resolveServerConfig(): void
+    protected function resolveServerConfig(array $environment = []): void
     {
         if (function_exists('app') && app()->bound('config')) {
             $servers = config('relay.servers', []);
@@ -520,7 +524,9 @@ class Relay
                 throw new ServerConfigurationException("MCP server '{$this->serverName}' is not configured.");
             }
 
-            $this->serverConfig = $servers[$this->serverName];
+            $configEnvironment = $servers[$this->serverName]['env'] ?? [];
+
+            $this->serverConfig = [...$servers[$this->serverName], 'env' => [...$configEnvironment, ...$environment]];
         } else {
             // Fallback for testing
             $this->serverConfig = [

--- a/src/RelayFactory.php
+++ b/src/RelayFactory.php
@@ -11,21 +11,24 @@ use Prism\Relay\Exceptions\ToolDefinitionException;
 class RelayFactory
 {
     /**
+     * @param  array<string, mixed>  $environment
+     *
      * @throws ServerConfigurationException
      */
-    public function make(string $serverName): Relay
+    public function make(string $serverName, array $environment = []): Relay
     {
-        return new Relay($serverName);
+        return new Relay($serverName, $environment);
     }
 
     /**
+     * @param  array<string, mixed>  $environment
      * @return array<int, Tool>
      *
      * @throws ServerConfigurationException
      * @throws ToolDefinitionException
      */
-    public function tools(string $serverName): array
+    public function tools(string $serverName, array $environment = []): array
     {
-        return $this->make($serverName)->tools();
+        return $this->make($serverName, $environment)->tools();
     }
 }

--- a/tests/Feature/Facades/RelayFacadeTest.php
+++ b/tests/Feature/Facades/RelayFacadeTest.php
@@ -35,13 +35,14 @@ it('can get tools through the facade', function (): void {
     config()->set('relay.servers.tools_test', [
         'url' => 'http://example.com/api',
         'timeout' => 30,
+        'env' => ['DEFAULT_VAR' => 'value'],
     ]);
 
     // Mock the actual HTTP calls that would happen under the hood
     $mock = $this->mock(RelayFactory::class);
     $mock->shouldReceive('tools')
         ->once()
-        ->with('tools_test')
+        ->withArgs(fn ($server, $env = []): bool => $server === 'tools_test' && $env === [])
         ->andReturn([
             new \Prism\Prism\Tool,
             new \Prism\Prism\Tool,
@@ -54,4 +55,51 @@ it('can get tools through the facade', function (): void {
     expect($tools)
         ->toBeArray()
         ->toHaveCount(2);
+});
+
+it('forwards make method with environment variables', function (): void {
+    // Configure a test server
+    config()->set('relay.servers.env_facade_test', [
+        'url' => 'http://example.com/api',
+        'timeout' => 30,
+        'env' => ['CONFIG_VAR' => 'config_value'],
+    ]);
+
+    $customEnv = ['CUSTOM_VAR' => 'custom_value'];
+
+    // Create a relay instance with custom environment
+    $relay = Relay::make('env_facade_test', $customEnv);
+
+    expect($relay)
+        ->toBeInstanceOf(RelayClass::class)
+        ->and($relay->getServerName())
+        ->toBe('env_facade_test');
+});
+
+it('forwards tools method with environment variables', function (): void {
+    // Configure a test server
+    config()->set('relay.servers.env_tools_test', [
+        'url' => 'http://example.com/api',
+        'timeout' => 30,
+        'env' => ['DEFAULT_VAR' => 'default'],
+    ]);
+
+    $customEnv = ['CUSTOM_VAR' => 'custom_value'];
+
+    // Mock the factory to verify environment is passed
+    $mock = $this->mock(RelayFactory::class);
+    $mock->shouldReceive('tools')
+        ->once()
+        ->with('env_tools_test', $customEnv)
+        ->andReturn([
+            new \Prism\Prism\Tool,
+        ]);
+
+    app()->instance('relay', $mock);
+
+    $tools = Relay::tools('env_tools_test', $customEnv);
+
+    expect($tools)
+        ->toBeArray()
+        ->toHaveCount(1);
 });

--- a/tests/TestDoubles/RelayFake.php
+++ b/tests/TestDoubles/RelayFake.php
@@ -20,6 +20,12 @@ class RelayFake extends Relay
 
     protected string $toolsExceptionMessage = 'Failed to fetch tools';
 
+    /** @return array<string, mixed>  */
+    public function getEnvironment(): array
+    {
+        return $this->serverConfig['env'] ?? [];
+    }
+
     /**
      * Sets a custom transport for testing purposes.
      *

--- a/tests/TestDoubles/StdioTransportFake.php
+++ b/tests/TestDoubles/StdioTransportFake.php
@@ -165,4 +165,10 @@ class StdioTransportFake extends StdioTransport
 
         return $this;
     }
+
+    /** @return array<string, mixed>  */
+    public function getEnvironment(): array
+    {
+        return $this->config['env'] ?? [];
+    }
 }

--- a/tests/Unit/RelayFactoryTest.php
+++ b/tests/Unit/RelayFactoryTest.php
@@ -10,6 +10,7 @@ it('creates a Relay instance', function (): void {
     config()->set('relay.servers.test_server', [
         'url' => 'http://example.com/api',
         'timeout' => 30,
+        'env' => ['DEFAULT_ENV' => 'value'],
     ]);
 
     $factory = new RelayFactory;
@@ -47,4 +48,22 @@ it('handles tool definition exceptions', function (): void {
     // Just verify we can safely access the tools method
     $factory = new RelayFactory;
     expect(method_exists($factory, 'tools'))->toBeTrue();
+});
+
+it('creates Relay instance with custom environment variables', function (): void {
+    config()->set('relay.servers.env_test', [
+        'url' => 'http://example.com/api',
+        'timeout' => 30,
+        'env' => ['CONFIG_VAR' => 'config_value'],
+    ]);
+
+    $factory = new RelayFactory;
+    $customEnv = ['CUSTOM_VAR' => 'custom_value'];
+
+    $relay = $factory->make('env_test', $customEnv);
+
+    expect($relay)
+        ->toBeInstanceOf(Relay::class)
+        ->and($relay->getServerName())
+        ->toBe('env_test');
 });

--- a/tests/Unit/Transport/StdioTransportTest.php
+++ b/tests/Unit/Transport/StdioTransportTest.php
@@ -162,3 +162,21 @@ it('closes in destructor', function (): void {
     unset($transport);
     expect(true)->toBeTrue();
 });
+
+it('receives merged environment variables from config', function (): void {
+    $env = [
+        'CONFIG_VAR' => 'config_value',
+        'OVERRIDE_ME' => 'overridden_value',
+        'CUSTOM_VAR' => 'custom_value',
+    ];
+
+    $config = [
+        'command' => ['test', 'command'],
+        'env' => $env,
+        'timeout' => 30,
+    ];
+
+    $transport = new StdioTransportFake($config);
+
+    expect($transport->getEnvironment())->toBe($env);
+});


### PR DESCRIPTION
## Description
This PR adds the possibility to pass runtime environment variables down to StdioTransports. I need this in some of my projects, where I dynamically pass the user's id and resolve their credentials on the mcp server.

Let me know what you think.

## Breaking Changes
None, falling back to no env.
