### PR TITLE
fix: add JSON Accept header to HTTP requests

### DIFF
--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -73,6 +73,7 @@ class HttpTransport implements Transport
     protected function sendHttpRequest(array $payload): Response
     {
         return Http::timeout($this->getTimeout())
+            ->acceptJson()
             ->when(
                 $this->hasApiKey(),
                 fn ($http) => $http->withToken($this->getApiKey())

--- a/tests/Unit/Transport/HttpTransportTest.php
+++ b/tests/Unit/Transport/HttpTransportTest.php
@@ -183,3 +183,22 @@ it('can make requests to tools/call', function (): void {
 
     expect($result)->toBeArray();
 });
+
+it('sends requests with JSON Accept header', function (): void {
+    $transport = new HttpTransport([
+        'url' => 'http://example.com/api',
+        'timeout' => 30,
+    ]);
+
+    Http::fake([
+        'http://example.com/api' => Http::response([
+            'jsonrpc' => '2.0',
+            'id' => '1',
+            'result' => ['status' => 'success'],
+        ]),
+    ]);
+
+    $transport->sendRequest('test/method');
+
+    Http::assertSent(fn ($request) => $request->hasHeader('Accept', 'application/json'));
+});


### PR DESCRIPTION
## Description
HttpTransport now sends requests with the 'Accept: application/json' header to ensure proper content negotiation. Added a unit test to verify the header is included in outgoing requests.

I have some server implementations breaking when I don't send that header.

## Breaking Changes
Possibly users who use implementations that explicitly don't accept the header. Would be weird tho.

We could make this configurable, but shouldn't be I think?
