### PR TITLE
Add Laravel AI SDK tool format support

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  phpv: 8.3
+  phpv: 8.4
 
 jobs:
   formatting:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -25,10 +25,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        run: composer update --prefer-stable --prefer-dist --no-interaction
-
-      - name: Install optional AI SDK dependencies
-        run: composer require laravel/ai --no-interaction
+        uses: ramsey/composer-install@v3
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  phpv: 8.3
+  phpv: 8.4
 
 jobs:
   phpstan:
@@ -25,7 +25,10 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        run: composer update --prefer-stable --prefer-dist --no-interaction
+
+      - name: Install optional AI SDK dependencies
+        run: composer require laravel/ai --no-interaction
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,10 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.3, 8.4]
-        laravel: [11.*, 12.*]
+        php: [8.4]
+        laravel: [12.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
-            carbon: ^2.63
           - laravel: 12.*
             testbench: 10.*
             carbon: ^3.8.4
@@ -48,10 +45,6 @@ jobs:
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
-
-      - name: Install optional AI SDK dependencies
-        if: matrix.php == '8.4' && matrix.laravel == '12.*' && matrix.stability == 'prefer-stable'
-        run: composer require laravel/ai --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,10 @@ jobs:
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
+      - name: Install optional AI SDK dependencies
+        if: matrix.php == '8.4' && matrix.laravel == '12.*' && matrix.stability == 'prefer-stable'
+        run: composer require laravel/ai --no-interaction
+
       - name: List Installed Dependencies
         run: composer show -D
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpunit.xml
 ray.php
 
 .claude/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ return [
             'transport' => \Prism\Relay\Enums\Transport::Http,
         ],
     ],
+    'tool_format' => \Prism\Relay\Enums\ToolFormat::RELAY, // ToolFormat::RELAY or ToolFormat::AI_SDK
     'cache_duration' => env('RELAY_TOOLS_CACHE_DURATION', 60), // in minutes (0 to disable)
 ];
 ```
@@ -76,6 +77,53 @@ return $response->text;
 ```
 
 The agent can now use any tools provided by the Puppeteer MCP server, such as navigating to webpages, taking screenshots, clicking buttons, and more.
+
+## Laravel AI SDK Usage
+
+Relay also supports the [Laravel AI SDK](https://github.com/laravel/ai) (`laravel/ai`). Set `tool_format` to `ToolFormat::AI_SDK` to have `Relay::tools()` return `Laravel\Ai\Contracts\Tool` instances instead of Prism tools.
+
+### Via config
+
+Set the format globally in `config/relay.php` or via the `RELAY_TOOL_FORMAT` environment variable:
+
+```php
+// config/relay.php
+'tool_format' => \Prism\Relay\Enums\ToolFormat::AI_SDK,
+```
+
+```ini
+# .env
+RELAY_TOOL_FORMAT=aisdk
+```
+
+Then use `Relay::tools()` as normal — it will return Laravel AI SDK-compatible tools:
+
+```php
+use Prism\Relay\Facades\Relay;
+
+$tools = Relay::tools('puppeteer');
+
+$response = \Laravel\Ai\Ai::text()
+    ->withTools($tools)
+    ->generate('Take a screenshot of laravel.com');
+```
+
+### Via runtime `format()`
+
+If you prefer to keep `tool_format` set to `ToolFormat::RELAY` globally, use the fluent `format()` setter to override it per call:
+
+```php
+use Prism\Relay\Enums\ToolFormat;
+use Prism\Relay\Facades\Relay;
+
+$tools = Relay::make('puppeteer')->format(ToolFormat::AI_SDK)->tools();
+```
+
+> [!NOTE]
+> AI SDK tool support requires `laravel/ai` and `illuminate/json-schema` (available in Laravel 12+). Install them with:
+> ```bash
+> composer require laravel/ai illuminate/json-schema
+> ```
 
 ## Real-World Example
 

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,7 @@
   "require": {
     "php": "^8.2",
     "prism-php/prism": ">=0.93 ^0",
-    "laravel/framework": "^11.0|^12.0",
-    "laravel/ai": "^0.2.1",
-    "illuminate/json-schema": "*"
+    "laravel/framework": "^11.0|^12.0"
   },
   "require-dev": {
     "pestphp/pest": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,10 @@
   "description": "A Prism tool for interacting with MCP servers",
   "type": "library",
   "require": {
-    "php": "^8.2",
+    "php": "^8.4",
     "prism-php/prism": ">=0.93 ^0",
-    "laravel/framework": "^11.0|^12.0"
+    "laravel/framework": "^12.0",
+    "laravel/ai": "^0"
   },
   "require-dev": {
     "pestphp/pest": "^3.0",
@@ -20,10 +21,6 @@
     "guzzlehttp/guzzle": "^7.8",
     "projektgopher/whisky": "^0.7.0",
     "mockery/mockery": "^1.6"
-  },
-  "suggest": {
-    "laravel/ai": "Required for the AI SDK tool format via format(ToolFormat::AI_SDK)->tools()",
-    "illuminate/json-schema": "Required for JSON Schema conversion in AI SDK tool format (included in Laravel 12+)"
   },
   "license": "MIT",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,9 @@
   "require": {
     "php": "^8.2",
     "prism-php/prism": ">=0.93 ^0",
-    "laravel/framework": "^11.0|^12.0"
+    "laravel/framework": "^11.0|^12.0",
+    "laravel/ai": "^0.2.1",
+    "illuminate/json-schema": "*"
   },
   "require-dev": {
     "pestphp/pest": "^3.0",
@@ -20,6 +22,10 @@
     "guzzlehttp/guzzle": "^7.8",
     "projektgopher/whisky": "^0.7.0",
     "mockery/mockery": "^1.6"
+  },
+  "suggest": {
+    "laravel/ai": "Required for the AI SDK tool format via format(ToolFormat::AI_SDK)->tools()",
+    "illuminate/json-schema": "Required for JSON Schema conversion in AI SDK tool format (included in Laravel 12+)"
   },
   "license": "MIT",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "php": "^8.4",
     "prism-php/prism": ">=0.93 ^0",
     "laravel/framework": "^12.0|^13.0",
-    "laravel/ai": "^0.2.1",
+    "laravel/ai": "^0.2.6",
     "illuminate/json-schema": "^12.41.1|^13.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,9 @@
   "require": {
     "php": "^8.4",
     "prism-php/prism": ">=0.93 ^0",
-    "laravel/framework": "^12.0",
-    "laravel/ai": "^0"
+    "laravel/framework": "^12.0|^13.0",
+    "laravel/ai": "^0.2.1",
+    "illuminate/json-schema": "^12.41.1|^13.0"
   },
   "require-dev": {
     "pestphp/pest": "^3.0",

--- a/config/relay.php
+++ b/config/relay.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Prism\Relay\Enums\ToolFormat;
 use Prism\Relay\Enums\Transport;
 
 return [
@@ -22,6 +23,18 @@ return [
             'env' => [],
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tool Format
+    |--------------------------------------------------------------------------
+    |
+    | Controls which format Relay::tools() returns. Use 'relay' (default) for
+    | Prism\Prism\Tool objects, or 'aisdk' for Laravel\Ai\Contracts\Tool
+    | objects compatible with the Laravel AI SDK (requires laravel/ai).
+    |
+    */
+    'tool_format' => ToolFormat::from(env('RELAY_TOOL_FORMAT', ToolFormat::RELAY->value)),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/relay.php
+++ b/config/relay.php
@@ -30,8 +30,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Controls which format Relay::tools() returns. Use 'relay' (default) for
-    | Prism\Prism\Tool objects, or 'aisdk' for Laravel\Ai\Contracts\Tool
-    | objects compatible with the Laravel AI SDK (requires laravel/ai).
+    | Prism\Prism\Tool objects, or 'aisdk' for Laravel\Ai\Contracts\Tool.
+    | The latter requires the Laravel AI SDK (the laravel/ai package).
     |
     */
     'tool_format' => ToolFormat::from(env('RELAY_TOOL_FORMAT', ToolFormat::RELAY->value)),

--- a/config/relay.php
+++ b/config/relay.php
@@ -29,9 +29,9 @@ return [
     | Tool Format
     |--------------------------------------------------------------------------
     |
-    | Controls which format Relay::tools() returns. Use 'relay' (default) for
-    | Prism\Prism\Tool objects, or 'aisdk' for Laravel\Ai\Contracts\Tool.
-    | The latter requires the Laravel AI SDK (the laravel/ai package).
+    | This option controls the format of tools returned by Relay::tools(). Set to
+    | 'relay' (the default) for Prism Tool objects, or set to 'aisdk' for the
+    | Laravel AI SDK contract. The 'aisdk' option requires the laravel/ai.
     |
     */
     'tool_format' => ToolFormat::from(env('RELAY_TOOL_FORMAT', ToolFormat::RELAY->value)),

--- a/rector.php
+++ b/rector.php
@@ -17,7 +17,7 @@ return RectorConfig::configure()
         InlineConstructorDefaultToPropertyRector::class,
     ])
     ->withSets([
-        LevelSetList::UP_TO_PHP_83,
+        LevelSetList::UP_TO_PHP_84,
         SetList::CODE_QUALITY,
         SetList::DEAD_CODE,
         SetList::EARLY_RETURN,

--- a/src/Enums/ToolFormat.php
+++ b/src/Enums/ToolFormat.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prism\Relay\Enums;
+
+enum ToolFormat: string
+{
+    case RELAY = 'relay';
+    case AI_SDK = 'aisdk';
+}

--- a/src/Facades/Relay.php
+++ b/src/Facades/Relay.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Prism\Relay\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Prism\Prism\Tool;
 use Prism\Relay\RelayFactory;
 
 /**
  * @method static \Prism\Relay\Relay make(string $serverName, array $config = null)
- * @method static array<int, Tool> tools(string $serverName, array $config = null)
+ * @method static array<int, \Prism\Prism\Tool|\Laravel\Ai\Contracts\Tool> tools(string $serverName, array $config = null)
  *
  * @see RelayFactory
  */

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Prism\Relay;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Prism\Prism\Contracts\Schema;
 use Prism\Prism\Schema\AnyOfSchema;
 use Prism\Prism\Schema\ArraySchema;
@@ -248,15 +249,23 @@ class Relay
 
         if ($type === null && isset($property['anyOf'])) {
             // The Laravel AI SDK does not support union types; fall back to string.
+            Log::warning('Relay: anyOf union type is not supported by the Laravel AI SDK; falling back to string.', [
+                'server' => $this->serverName,
+                'property' => $property,
+            ]);
+
             return $schema->string();
         }
 
         return match ($type) {
-            'string' => $schema->string(),
+            // In JSON Schema, enum values are a validation constraint on a type, not a type themselves.
+            // A string property with enum looks like {"type": "string", "enum": ["a", "b"]}.
+            'string' => isset($property['enum'])
+                ? $schema->string()->enum($property['enum'])
+                : $schema->string(),
             'number' => $schema->number(),
             'integer' => $schema->integer(),
             'boolean' => $schema->boolean(),
-            'enum' => $schema->string()->enum($property['options'] ?? $property['enum'] ?? []),
             'array' => $this->buildLaravelArrayType($schema, $property),
             'object' => $this->buildLaravelObjectType($schema, $property),
             default => null,
@@ -570,11 +579,10 @@ class Relay
 
     protected function extractBaseToolName(string $toolName): string
     {
-        if (str_starts_with($toolName, 'relay__')) {
-            $parts = explode('__', $toolName);
-            if (count($parts) >= 3) {
-                return end($parts);
-            }
+        $prefix = "relay__{$this->serverName}__";
+
+        if (str_starts_with($toolName, $prefix)) {
+            return substr($toolName, strlen($prefix));
         }
 
         return $toolName;
@@ -682,7 +690,7 @@ class Relay
         if (is_array($response) || is_object($response)) {
             $json = json_encode($response, JSON_PRETTY_PRINT);
 
-            return $json !== false ? $json : 'Tool executed successfully';
+            return $json !== false ? $json : 'Tool returned an unserializable result';
         }
 
         return 'Tool executed successfully';

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -14,6 +14,7 @@ use Prism\Prism\Schema\NumberSchema;
 use Prism\Prism\Schema\ObjectSchema;
 use Prism\Prism\Schema\StringSchema;
 use Prism\Prism\Tool;
+use Prism\Relay\Enums\ToolFormat;
 use Prism\Relay\Enums\Transport as EnumsTransport;
 use Prism\Relay\Exceptions\RelayException;
 use Prism\Relay\Exceptions\ServerConfigurationException;
@@ -31,6 +32,8 @@ class Relay
 
     protected Transport $transport;
 
+    protected ?ToolFormat $runtimeFormat = null;
+
     /**
      * @param  array<string, mixed>|null  $customConfig
      *
@@ -47,16 +50,41 @@ class Relay
         return $this->serverName;
     }
 
+    public function format(ToolFormat $format): static
+    {
+        $this->runtimeFormat = $format;
+
+        return $this;
+    }
+
     /**
-     * @return array<int, Tool>
+     * @return array<int, Tool|\Laravel\Ai\Contracts\Tool>
      *
      * @throws ToolDefinitionException
      */
     public function tools(): array
     {
+        $format = $this->runtimeFormat ?? config('relay.tool_format', ToolFormat::RELAY);
+
+        if ($format === ToolFormat::AI_SDK) {
+            return $this->laravelTools();
+        }
+
         $toolDefinitions = $this->fetchToolDefinitions();
 
         return $this->createToolsFromDefinitions($toolDefinitions);
+    }
+
+    /**
+     * @return array<int, \Laravel\Ai\Contracts\Tool>
+     *
+     * @throws ToolDefinitionException
+     */
+    protected function laravelTools(): array
+    {
+        $toolDefinitions = $this->fetchToolDefinitions();
+
+        return $this->createLaravelToolsFromDefinitions($toolDefinitions);
     }
 
     /**
@@ -98,17 +126,11 @@ class Relay
      */
     protected function parseToolsResult(array $toolsResult): array
     {
-        $tools = data_get($toolsResult, 'tools');
-
-        if (is_array($tools)) {
-            return $tools;
-        }
-
         if (! isset($toolsResult['tools'])) {
             return array_values($toolsResult);
         }
 
-        return [];
+        return is_array($toolsResult['tools']) ? $toolsResult['tools'] : [];
     }
 
     /**
@@ -131,6 +153,158 @@ class Relay
         }
 
         return $tools;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $toolDefinitions
+     * @return array<int, \Laravel\Ai\Contracts\Tool>
+     */
+    protected function createLaravelToolsFromDefinitions(array $toolDefinitions): array
+    {
+        $tools = [];
+
+        foreach ($toolDefinitions as $definition) {
+            if (! $this->isValidToolDefinition($definition)) {
+                continue;
+            }
+
+            $toolName = "relay__{$this->serverName}__{$definition['name']}";
+            $toolDescription = $definition['description'];
+
+            $handler = fn (string $name, array $params): string => $this->callMCPTool($name, $params);
+            $schemaFn = fn (\Illuminate\Contracts\JsonSchema\JsonSchema $schema): array => $this->buildLaravelSchemaArray($schema, $definition);
+
+            $tools[] = new class($toolName, $toolDescription, $handler, $schemaFn) implements \Laravel\Ai\Contracts\Tool
+            {
+                public function __construct(
+                    private readonly string $toolName,
+                    private readonly string $toolDescription,
+                    private readonly \Closure $handler,
+                    private readonly \Closure $schemaFn,
+                ) {}
+
+                public function name(): string
+                {
+                    return $this->toolName;
+                }
+
+                public function description(): string
+                {
+                    return $this->toolDescription;
+                }
+
+                /**
+                 * @return array<string, \Illuminate\JsonSchema\Types\Type>
+                 */
+                public function schema(\Illuminate\Contracts\JsonSchema\JsonSchema $schema): array
+                {
+                    return ($this->schemaFn)($schema);
+                }
+
+                public function handle(\Laravel\Ai\Tools\Request $request): string
+                {
+                    return ($this->handler)($this->toolName, $request->all());
+                }
+            };
+        }
+
+        return $tools;
+    }
+
+    /**
+     * @param  array<string, mixed>  $definition
+     * @return array<string, \Illuminate\JsonSchema\Types\Type>
+     */
+    protected function buildLaravelSchemaArray(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $definition): array
+    {
+        $properties = data_get($definition, 'inputSchema.properties', []);
+        $required = data_get($definition, 'inputSchema.required', []);
+        $result = [];
+
+        foreach ($properties as $name => $property) {
+            $type = $this->buildLaravelTypeFromProperty($schema, (string) $name, $property, (string) data_get($definition, 'name', 'unknown'));
+            if (!$type instanceof \Illuminate\JsonSchema\Types\Type) {
+                continue;
+            }
+
+            $type = $type->description($this->getParameterDescription((string) $name, $property, (string) data_get($definition, 'name', 'unknown')));
+
+            if (in_array($name, $required)) {
+                $type = $type->required();
+            }
+
+            $result[$name] = $type;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, mixed>  $property
+     */
+    protected function buildLaravelTypeFromProperty(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, string $name, array $property, string $definitionName): ?\Illuminate\JsonSchema\Types\Type
+    {
+        if ($property === []) {
+            return null;
+        }
+
+        $type = $property['type'] ?? null;
+
+        if ($type === null && isset($property['anyOf'])) {
+            return $schema->string();
+        }
+
+        return match ($type) {
+            'string' => $schema->string(),
+            'number' => $schema->number(),
+            'integer' => $schema->integer(),
+            'boolean' => $schema->boolean(),
+            'enum' => $schema->string()->enum($property['options'] ?? $property['enum'] ?? []),
+            'array' => $this->buildLaravelArrayType($schema, $property, $definitionName),
+            'object' => $this->buildLaravelObjectType($schema, $property, $definitionName),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $property
+     */
+    protected function buildLaravelArrayType(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property, string $definitionName): \Illuminate\JsonSchema\Types\ArrayType
+    {
+        $arrayType = $schema->array();
+
+        $items = data_get($property, 'items', []);
+        if ($items !== []) {
+            $itemType = $this->buildLaravelTypeFromProperty($schema, '', $items, $definitionName);
+            if ($itemType instanceof \Illuminate\JsonSchema\Types\Type) {
+                $arrayType->items($itemType);
+            }
+        }
+
+        return $arrayType;
+    }
+
+    /**
+     * @param  array<string, mixed>  $property
+     */
+    protected function buildLaravelObjectType(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property, string $definitionName): \Illuminate\JsonSchema\Types\ObjectType
+    {
+        $nestedProperties = [];
+
+        foreach (data_get($property, 'properties', []) as $propName => $propDef) {
+            $propType = $this->buildLaravelTypeFromProperty($schema, (string) $propName, $propDef, $definitionName);
+            if ($propType instanceof \Illuminate\JsonSchema\Types\Type) {
+                $nestedProperties[$propName] = $propType;
+            }
+        }
+
+        $objectType = $schema->object($nestedProperties);
+
+        if (data_get($property, 'allowAdditionalProperties', true) === false) {
+            $objectType->withoutAdditionalProperties();
+        }
+
+        return $objectType;
     }
 
     /**
@@ -163,9 +337,6 @@ class Relay
      */
     protected function createHandlerFunction(string $toolName, array $definition): callable
     {
-        $this->getRequiredParameters($definition);
-
-        // Check for specific tool types based on required parameters and create specialized handlers
         if ($this->isUrlBasedTool($definition)) {
             return fn ($url = null): string => $this->callMCPTool($toolName, ['url' => $url]);
         }
@@ -189,19 +360,15 @@ class Relay
             return fn ($script = null): string => $this->callMCPTool($toolName, ['script' => $script]);
         }
 
-        // Default generic handler for any other tool - handle both individual params and array
         return function (...$args) use ($toolName, $definition): string {
-            // Check if we have named parameters (associative array)
             if ($args !== [] && array_keys($args) !== range(0, count($args) - 1)) {
-                // We have named parameters, use them directly
                 return $this->callMCPTool($toolName, $args);
             }
-            // If first argument is an array, use it as parameters
+
             if (count($args) === 1 && isset($args[0]) && is_array($args[0])) {
                 return $this->callMCPTool($toolName, $args[0]);
             }
 
-            // Otherwise, map positional arguments to parameter names
             $requiredParams = $this->getRequiredParameters($definition);
             $parameters = [];
 
@@ -326,7 +493,6 @@ class Relay
     {
         $parameters = [];
         foreach ($properties as $name => $property) {
-
             $parameter = $this->getSchemeParameter((string) $name, $property, $definitionName);
             if ($parameter instanceof Schema) {
                 $parameters[] = $parameter;
@@ -389,15 +555,13 @@ class Relay
     }
 
     /**
-     * @param  array<string|int, mixed>|object|string  $parameters
-     *
      * @throws ToolCallException
      */
-    protected function callMCPTool(string $toolName, $parameters): string
+    protected function callMCPTool(string $toolName, mixed $parameters): string
     {
         try {
             $baseToolName = $this->extractBaseToolName($toolName);
-            $normalizedParams = $this->normalizeParameters($baseToolName, $parameters);
+            $normalizedParams = $this->normalizeParameters($parameters);
 
             $result = $this->executeMCPToolCall($baseToolName, $normalizedParams);
 
@@ -420,37 +584,28 @@ class Relay
     }
 
     /**
-     * @param  array<string|int, mixed>|object|string  $parameters
      * @return array<string, mixed>
      */
-    protected function normalizeParameters(string $baseToolName, $parameters): array
+    protected function normalizeParameters(mixed $parameters): array
     {
-        // If the parameter is a string, convert it to a default parameter format
         if (is_string($parameters)) {
-            // If the tool requires a URL, use that as the key
-            if ($this->isUrlParameter($baseToolName, $parameters)) {
-                return ['url' => $parameters];
-            }
-
-            // Default to using 'text' as the key
-            return ['text' => $parameters];
+            return $this->isUrlParameter($parameters)
+                ? ['url' => $parameters]
+                : ['text' => $parameters];
         }
 
-        // If the parameter is an object, convert it to an array
         if (is_object($parameters)) {
             return (array) $parameters;
         }
 
-        // If it's already an array, return it
         if (is_array($parameters)) {
             return $parameters;
         }
 
-        // Default to empty parameters
         return [];
     }
 
-    protected function isUrlParameter(string $toolName, string $parameter): bool
+    protected function isUrlParameter(string $parameter): bool
     {
         return (filter_var($parameter, FILTER_VALIDATE_URL) !== false) &&
             (str_starts_with($parameter, 'http://') || str_starts_with($parameter, 'https://'));
@@ -462,16 +617,10 @@ class Relay
      */
     protected function executeMCPToolCall(string $toolName, array $parameters): array
     {
-        // MCP requires arguments to be an object, not an array
-        $normalizedParamsObject = (object) $parameters;
-
-        $requestParams = [
+        return $this->transport->sendRequest('tools/call', [
             'name' => $toolName,
-            'arguments' => $normalizedParamsObject,
-        ];
-
-        // Call the tool using JSON-RPC format with correct MCP endpoint: tools/call
-        return $this->transport->sendRequest('tools/call', $requestParams);
+            'arguments' => (object) $parameters,
+        ]);
     }
 
     /**
@@ -479,12 +628,10 @@ class Relay
      */
     protected function formatToolResponse(array $response): string
     {
-        // MCP responses may have a content array with text and image items
         if (isset($response['content']) && is_array($response['content'])) {
             return $this->formatContentResponse($response);
         }
 
-        // For other response formats, convert to a string
         return $this->convertResponseToString($response);
     }
 
@@ -510,50 +657,38 @@ class Relay
 
         $prefix = $isError ? 'ERROR: ' : '';
 
-        // Return text content if available
         if ($texts !== []) {
             return $prefix.implode("\n", $texts);
         }
 
-        // Return image references if available and no text
         if ($images !== []) {
             return $prefix.implode("\n", $images);
         }
 
-        // Default message for empty content
         return $prefix.'Tool executed'.($prefix === '' ? ' successfully' : '');
     }
 
     protected function convertResponseToString(mixed $response): string
     {
-        // Default success message
-        $defaultMessage = 'Tool executed successfully';
-
         if (is_string($response)) {
             return $response;
-        }
-
-        if (is_array($response)) {
-            $json = json_encode($response, JSON_PRETTY_PRINT);
-
-            return $json !== false ? $json : $defaultMessage;
         }
 
         if (is_scalar($response)) {
             return (string) $response;
         }
 
-        if (is_object($response)) {
-            if (method_exists($response, '__toString')) {
-                return (string) $response;
-            }
-
-            $json = json_encode($response, JSON_PRETTY_PRINT);
-
-            return $json !== false ? $json : 'Tool returned an object result';
+        if (is_object($response) && method_exists($response, '__toString')) {
+            return (string) $response;
         }
 
-        return $defaultMessage;
+        if (is_array($response) || is_object($response)) {
+            $json = json_encode($response, JSON_PRETTY_PRINT);
+
+            return $json !== false ? $json : 'Tool executed successfully';
+        }
+
+        return 'Tool executed successfully';
     }
 
     /**

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -78,7 +78,7 @@ class Relay
     }
 
     /**
-     * @return array<int, Tool>
+     * @return array<int, Tool|\Laravel\Ai\Contracts\Tool>
      *
      * @throws ToolDefinitionException
      */

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -296,10 +296,14 @@ class Relay
     protected function buildLaravelObjectType(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property): \Illuminate\JsonSchema\Types\ObjectType
     {
         $nestedProperties = [];
+        $nestedRequired = data_get($property, 'required', []);
 
         foreach (data_get($property, 'properties', []) as $propName => $propDef) {
             $propType = $this->buildLaravelTypeFromProperty($schema, $propDef);
             if ($propType instanceof \Illuminate\JsonSchema\Types\Type) {
+                if (in_array($propName, $nestedRequired)) {
+                    $propType = $propType->required();
+                }
                 $nestedProperties[$propName] = $propType;
             }
         }

--- a/src/Relay.php
+++ b/src/Relay.php
@@ -67,24 +67,18 @@ class Relay
         $format = $this->runtimeFormat ?? config('relay.tool_format', ToolFormat::RELAY);
 
         if ($format === ToolFormat::AI_SDK) {
-            return $this->laravelTools();
+            if (! interface_exists(\Laravel\Ai\Contracts\Tool::class) || ! interface_exists(\Illuminate\Contracts\JsonSchema\JsonSchema::class)) {
+                throw new ToolDefinitionException(
+                    'ToolFormat::AI_SDK requires the laravel/ai and illuminate/json-schema packages. Install them with: composer require laravel/ai illuminate/json-schema'
+                );
+            }
+
+            return $this->createLaravelToolsFromDefinitions($this->fetchToolDefinitions());
         }
 
         $toolDefinitions = $this->fetchToolDefinitions();
 
         return $this->createToolsFromDefinitions($toolDefinitions);
-    }
-
-    /**
-     * @return array<int, \Laravel\Ai\Contracts\Tool>
-     *
-     * @throws ToolDefinitionException
-     */
-    protected function laravelTools(): array
-    {
-        $toolDefinitions = $this->fetchToolDefinitions();
-
-        return $this->createLaravelToolsFromDefinitions($toolDefinitions);
     }
 
     /**
@@ -221,13 +215,15 @@ class Relay
         $required = data_get($definition, 'inputSchema.required', []);
         $result = [];
 
+        $definitionName = (string) data_get($definition, 'name', 'unknown');
+
         foreach ($properties as $name => $property) {
-            $type = $this->buildLaravelTypeFromProperty($schema, (string) $name, $property, (string) data_get($definition, 'name', 'unknown'));
-            if (!$type instanceof \Illuminate\JsonSchema\Types\Type) {
+            $type = $this->buildLaravelTypeFromProperty($schema, $property);
+            if (! $type instanceof \Illuminate\JsonSchema\Types\Type) {
                 continue;
             }
 
-            $type = $type->description($this->getParameterDescription((string) $name, $property, (string) data_get($definition, 'name', 'unknown')));
+            $type = $type->description($this->getParameterDescription((string) $name, $property, $definitionName));
 
             if (in_array($name, $required)) {
                 $type = $type->required();
@@ -242,7 +238,7 @@ class Relay
     /**
      * @param  array<string, mixed>  $property
      */
-    protected function buildLaravelTypeFromProperty(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, string $name, array $property, string $definitionName): ?\Illuminate\JsonSchema\Types\Type
+    protected function buildLaravelTypeFromProperty(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property): ?\Illuminate\JsonSchema\Types\Type
     {
         if ($property === []) {
             return null;
@@ -251,6 +247,7 @@ class Relay
         $type = $property['type'] ?? null;
 
         if ($type === null && isset($property['anyOf'])) {
+            // The Laravel AI SDK does not support union types; fall back to string.
             return $schema->string();
         }
 
@@ -260,8 +257,8 @@ class Relay
             'integer' => $schema->integer(),
             'boolean' => $schema->boolean(),
             'enum' => $schema->string()->enum($property['options'] ?? $property['enum'] ?? []),
-            'array' => $this->buildLaravelArrayType($schema, $property, $definitionName),
-            'object' => $this->buildLaravelObjectType($schema, $property, $definitionName),
+            'array' => $this->buildLaravelArrayType($schema, $property),
+            'object' => $this->buildLaravelObjectType($schema, $property),
             default => null,
         };
     }
@@ -269,13 +266,13 @@ class Relay
     /**
      * @param  array<string, mixed>  $property
      */
-    protected function buildLaravelArrayType(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property, string $definitionName): \Illuminate\JsonSchema\Types\ArrayType
+    protected function buildLaravelArrayType(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property): \Illuminate\JsonSchema\Types\ArrayType
     {
         $arrayType = $schema->array();
 
         $items = data_get($property, 'items', []);
         if ($items !== []) {
-            $itemType = $this->buildLaravelTypeFromProperty($schema, '', $items, $definitionName);
+            $itemType = $this->buildLaravelTypeFromProperty($schema, $items);
             if ($itemType instanceof \Illuminate\JsonSchema\Types\Type) {
                 $arrayType->items($itemType);
             }
@@ -287,12 +284,12 @@ class Relay
     /**
      * @param  array<string, mixed>  $property
      */
-    protected function buildLaravelObjectType(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property, string $definitionName): \Illuminate\JsonSchema\Types\ObjectType
+    protected function buildLaravelObjectType(\Illuminate\Contracts\JsonSchema\JsonSchema $schema, array $property): \Illuminate\JsonSchema\Types\ObjectType
     {
         $nestedProperties = [];
 
         foreach (data_get($property, 'properties', []) as $propName => $propDef) {
-            $propType = $this->buildLaravelTypeFromProperty($schema, (string) $propName, $propDef, $definitionName);
+            $propType = $this->buildLaravelTypeFromProperty($schema, $propDef);
             if ($propType instanceof \Illuminate\JsonSchema\Types\Type) {
                 $nestedProperties[$propName] = $propType;
             }

--- a/src/RelayBuilder.php
+++ b/src/RelayBuilder.php
@@ -22,7 +22,7 @@ class RelayBuilder
 
     /**
      * @param  array<string, mixed>|null  $config
-     * @return array<int, Tool>
+     * @return array<int, Tool|\Laravel\Ai\Contracts\Tool>
      *
      * @throws \Prism\Relay\Exceptions\ServerConfigurationException
      * @throws \Prism\Relay\Exceptions\ToolDefinitionException

--- a/src/RelayFactory.php
+++ b/src/RelayFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Prism\Relay;
 
-use Prism\Prism\Tool;
 use Prism\Relay\Exceptions\ServerConfigurationException;
 use Prism\Relay\Exceptions\ToolDefinitionException;
 
@@ -22,7 +21,7 @@ class RelayFactory
 
     /**
      * @param  array<string, mixed>|null  $config
-     * @return array<int, Tool>
+     * @return array<int, \Prism\Prism\Tool|\Laravel\Ai\Contracts\Tool>
      *
      * @throws ServerConfigurationException
      * @throws ToolDefinitionException

--- a/tests/TestDoubles/RelayFake.php
+++ b/tests/TestDoubles/RelayFake.php
@@ -207,6 +207,11 @@ class RelayFake extends Relay
         ];
     }
 
+    public function extractBaseToolNamePublic(string $toolName): string
+    {
+        return $this->extractBaseToolName($toolName);
+    }
+
     #[\Override]
     protected function callMCPTool(string $toolName, mixed $parameters): string
     {

--- a/tests/TestDoubles/RelayFake.php
+++ b/tests/TestDoubles/RelayFake.php
@@ -207,11 +207,8 @@ class RelayFake extends Relay
         ];
     }
 
-    /**
-     * @param  array<string, mixed>|object|string  $parameters
-     */
     #[\Override]
-    protected function callMCPTool(string $toolName, $parameters): string
+    protected function callMCPTool(string $toolName, mixed $parameters): string
     {
         // Return predictable results for testing
         if (is_string($parameters)) {

--- a/tests/Unit/RelayLaravelToolsTest.php
+++ b/tests/Unit/RelayLaravelToolsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Prism\Relay\Enums\ToolFormat;
+use Prism\Relay\Exceptions\ToolDefinitionException;
+use Tests\TestDoubles\RelayFake;
+
+beforeEach(function (): void {
+    $this->serverName = 'test_server';
+    config()->set('relay.servers.'.$this->serverName, [
+        'url' => 'http://example.com/api',
+        'timeout' => 30,
+    ]);
+    Cache::forget('relay-tools-definitions-'.$this->serverName);
+});
+
+it('returns an array of Laravel AI SDK tools', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    expect($tools)
+        ->toBeArray()
+        ->not->toBeEmpty()
+        ->and($tools[0])
+        ->toBeInstanceOf(Tool::class);
+});
+
+it('generates namespaced tool names', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    expect($tools[0]->name())->toBe("relay__{$this->serverName}__test_tool");
+});
+
+it('returns correct tool description', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    expect($tools[0]->description())->toBe('A test tool for testing');
+});
+
+it('builds schema with correct types for primitive parameters', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    // test_tool has param1 (string, required), param2 (number), param3 (boolean)
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[0]->schema($schema);
+
+    expect($params)
+        ->toHaveKey('param1')
+        ->toHaveKey('param2')
+        ->toHaveKey('param3')
+        ->and($params['param1']->toArray()['type'])->toBe('string')
+        ->and($params['param2']->toArray())->toHaveKey('type')
+        ->and($params['param3']->toArray()['type'])->toBe('boolean');
+});
+
+it('marks required parameters via the required flag on the type', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    // test_tool: only param1 is required -- use reflection to inspect the protected property
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[0]->schema($schema);
+
+    $reqProp = new \ReflectionProperty($params['param1'], 'required');
+    $optProp = new \ReflectionProperty($params['param2'], 'required');
+
+    expect($reqProp->getValue($params['param1']))->toBeTrue()
+        ->and($optProp->getValue($params['param2']))->toBeNull();
+});
+
+it('falls back to string type for anyOf parameters', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    // union_tool (index 6) has nameOrId with anyOf
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[6]->schema($schema);
+
+    expect($params)
+        ->toHaveKey('nameOrId')
+        ->and($params['nameOrId']->toArray()['type'])->toBe('string');
+});
+
+it('handle() routes through to callMCPTool', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    $request = new Request(['param1' => 'hello']);
+    $result = $tools[0]->handle($request);
+
+    expect($result)
+        ->toContain('test_tool')
+        ->toContain('hello');
+});
+
+it('throws ToolDefinitionException when tool definitions fail', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $relay->shouldThrowOnTools('Fetch failed');
+
+    expect(fn (): array => $relay->format(ToolFormat::AI_SDK)->tools())
+        ->toThrow(ToolDefinitionException::class, 'Fetch failed');
+});
+
+it('returns correct count of tools', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    expect($tools)->toHaveCount(7);
+});
+
+it('includes all parameters in tool schema', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[1]->schema($schema);
+
+    expect($params)->toHaveKey('url')
+        ->and($params['url']->toArray()['type'])->toBe('string');
+});

--- a/tests/Unit/RelayLaravelToolsTest.php
+++ b/tests/Unit/RelayLaravelToolsTest.php
@@ -15,6 +15,10 @@ use Tests\TestDoubles\FakeTransport;
 use Tests\TestDoubles\RelayFake;
 
 beforeEach(function (): void {
+    if (! interface_exists(\Laravel\Ai\Contracts\Tool::class)) {
+        test()->skip('laravel/ai package not installed');
+    }
+
     $this->serverName = 'test_server';
     config()->set('relay.servers.'.$this->serverName, [
         'url' => 'http://example.com/api',

--- a/tests/Unit/RelayLaravelToolsTest.php
+++ b/tests/Unit/RelayLaravelToolsTest.php
@@ -237,6 +237,40 @@ it('builds schema with enum constraint on a string type', function (): void {
         ->and($statusArray['enum'])->toBe(['active', 'inactive', 'pending']);
 });
 
+it('preserves required flags for nested object properties', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $relay->setToolDefinitions([[
+        'name' => 'nested_tool',
+        'description' => 'A tool with a nested object',
+        'inputSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'config' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'host' => ['type' => 'string', 'description' => 'Host'],
+                        'port' => ['type' => 'integer', 'description' => 'Port'],
+                        'debug' => ['type' => 'boolean', 'description' => 'Debug flag'],
+                    ],
+                    'required' => ['host', 'port'],
+                ],
+            ],
+            'required' => ['config'],
+        ],
+    ]]);
+
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+    $schema = new \Illuminate\JsonSchema\JsonSchemaTypeFactory;
+    $params = $tools[0]->schema($schema);
+
+    $configArray = $params['config']->toArray();
+
+    expect($configArray)->toHaveKey('required')
+        ->and($configArray['required'])->toContain('host')
+        ->and($configArray['required'])->toContain('port')
+        ->and($configArray['required'])->not->toContain('debug');
+});
+
 it('handle() calls the transport with the base tool name, not the namespaced name', function (): void {
     $fakeTransport = new FakeTransport;
     $fakeTransport->addResponse('tools/call', ['content' => [['type' => 'text', 'text' => 'ok']]]);

--- a/tests/Unit/RelayLaravelToolsTest.php
+++ b/tests/Unit/RelayLaravelToolsTest.php
@@ -10,6 +10,8 @@ use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
 use Prism\Relay\Enums\ToolFormat;
 use Prism\Relay\Exceptions\ToolDefinitionException;
+use Prism\Relay\Relay;
+use Tests\TestDoubles\FakeTransport;
 use Tests\TestDoubles\RelayFake;
 
 beforeEach(function (): void {
@@ -63,22 +65,20 @@ it('builds schema with correct types for primitive parameters', function (): voi
         ->and($params['param3']->toArray()['type'])->toBe('boolean');
 });
 
-it('marks required parameters via the required flag on the type', function (): void {
+it('marks required parameters correctly in the serialized schema', function (): void {
     $relay = new RelayFake($this->serverName);
     $tools = $relay->format(ToolFormat::AI_SDK)->tools();
 
     // test_tool: only param1 is required.
-    // illuminate/json-schema tracks `required` as parent-object state in JSON Schema,
-    // so it isn't exposed via a public method on Type — reflection is the only way to
-    // verify the flag was set before the schema is serialised.
     $schema = new JsonSchemaTypeFactory;
     $params = $tools[0]->schema($schema);
 
-    $reqProp = new \ReflectionProperty($params['param1'], 'required');
-    $optProp = new \ReflectionProperty($params['param2'], 'required');
+    // Wrap in an object type to observe the serialized required list.
+    $serialized = $schema->object($params)->toArray();
 
-    expect($reqProp->getValue($params['param1']))->toBeTrue()
-        ->and($optProp->getValue($params['param2']))->toBeNull();
+    expect($serialized)->toHaveKey('required')
+        ->and($serialized['required'])->toContain('param1')
+        ->and($serialized['required'])->not->toContain('param2');
 });
 
 it('falls back to string type for anyOf parameters', function (): void {
@@ -130,4 +130,144 @@ it('includes all parameters in tool schema', function (): void {
 
     expect($params)->toHaveKey('url')
         ->and($params['url']->toArray()['type'])->toBe('string');
+});
+
+it('builds schema with integer type', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $relay->setToolDefinitions([[
+        'name' => 'int_tool',
+        'description' => 'A tool with an integer parameter',
+        'inputSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'count' => ['type' => 'integer', 'description' => 'Count'],
+            ],
+            'required' => ['count'],
+        ],
+    ]]);
+
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[0]->schema($schema);
+
+    expect($params)->toHaveKey('count')
+        ->and($params['count']->toArray()['type'])->toBe('integer');
+});
+
+it('builds schema with array type', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $relay->setToolDefinitions([[
+        'name' => 'array_tool',
+        'description' => 'A tool with an array parameter',
+        'inputSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'tags' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'description' => 'List of tags',
+                ],
+            ],
+            'required' => ['tags'],
+        ],
+    ]]);
+
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[0]->schema($schema);
+
+    expect($params)->toHaveKey('tags')
+        ->and($params['tags']->toArray()['type'])->toBe('array');
+});
+
+it('builds schema with object type', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $relay->setToolDefinitions([[
+        'name' => 'object_tool',
+        'description' => 'A tool with an object parameter',
+        'inputSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'config' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'key' => ['type' => 'string'],
+                        'value' => ['type' => 'string'],
+                    ],
+                    'description' => 'Config object',
+                ],
+            ],
+            'required' => ['config'],
+        ],
+    ]]);
+
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[0]->schema($schema);
+
+    expect($params)->toHaveKey('config')
+        ->and($params['config']->toArray()['type'])->toBe('object');
+});
+
+it('builds schema with enum constraint on a string type', function (): void {
+    $relay = new RelayFake($this->serverName);
+    $relay->setToolDefinitions([[
+        'name' => 'enum_tool',
+        'description' => 'A tool with an enum-constrained string',
+        'inputSchema' => [
+            'type' => 'object',
+            'properties' => [
+                'status' => [
+                    'type' => 'string',
+                    'enum' => ['active', 'inactive', 'pending'],
+                    'description' => 'Status',
+                ],
+            ],
+            'required' => ['status'],
+        ],
+    ]]);
+
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+    $schema = new JsonSchemaTypeFactory;
+    $params = $tools[0]->schema($schema);
+
+    $statusArray = $params['status']->toArray();
+    expect($statusArray['type'])->toBe('string')
+        ->and($statusArray)->toHaveKey('enum')
+        ->and($statusArray['enum'])->toBe(['active', 'inactive', 'pending']);
+});
+
+it('handle() calls the transport with the base tool name, not the namespaced name', function (): void {
+    $fakeTransport = new FakeTransport;
+    $fakeTransport->addResponse('tools/call', ['content' => [['type' => 'text', 'text' => 'ok']]]);
+
+    $relay = new class($this->serverName) extends Relay
+    {
+        public function setTransport(\Prism\Relay\Transport\Transport $transport): void
+        {
+            $this->transport = $transport;
+        }
+
+        #[\Override]
+        protected function fetchToolDefinitions(): array
+        {
+            return [[
+                'name' => 'test_tool',
+                'description' => 'Test tool',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => ['p' => ['type' => 'string', 'description' => 'P']],
+                    'required' => ['p'],
+                ],
+            ]];
+        }
+    };
+
+    $relay->setTransport($fakeTransport);
+    $tools = $relay->format(ToolFormat::AI_SDK)->tools();
+
+    $tools[0]->handle(new Request(['p' => 'val']));
+
+    $lastRequest = $fakeTransport->lastRequest();
+    expect($lastRequest['params']['name'])->toBe('test_tool');
 });

--- a/tests/Unit/RelayLaravelToolsTest.php
+++ b/tests/Unit/RelayLaravelToolsTest.php
@@ -15,10 +15,6 @@ use Tests\TestDoubles\FakeTransport;
 use Tests\TestDoubles\RelayFake;
 
 beforeEach(function (): void {
-    if (! interface_exists(\Laravel\Ai\Contracts\Tool::class)) {
-        test()->skip('laravel/ai package not installed');
-    }
-
     $this->serverName = 'test_server';
     config()->set('relay.servers.'.$this->serverName, [
         'url' => 'http://example.com/api',

--- a/tests/Unit/RelayLaravelToolsTest.php
+++ b/tests/Unit/RelayLaravelToolsTest.php
@@ -67,7 +67,10 @@ it('marks required parameters via the required flag on the type', function (): v
     $relay = new RelayFake($this->serverName);
     $tools = $relay->format(ToolFormat::AI_SDK)->tools();
 
-    // test_tool: only param1 is required -- use reflection to inspect the protected property
+    // test_tool: only param1 is required.
+    // illuminate/json-schema tracks `required` as parent-object state in JSON Schema,
+    // so it isn't exposed via a public method on Type — reflection is the only way to
+    // verify the flag was set before the schema is serialised.
     $schema = new JsonSchemaTypeFactory;
     $params = $tools[0]->schema($schema);
 

--- a/tests/Unit/RelayTest.php
+++ b/tests/Unit/RelayTest.php
@@ -115,7 +115,7 @@ it('returns laravel ai tools when tool_format is aisdk', function (): void {
     $tools = $relay->tools();
 
     expect($tools[0])->toBeInstanceOf(\Laravel\Ai\Contracts\Tool::class);
-});
+})->skip(fn (): bool => ! interface_exists(\Laravel\Ai\Contracts\Tool::class), 'laravel/ai package not installed');
 
 it('runtime format() overrides config tool_format', function (): void {
     config()->set('relay.tool_format', ToolFormat::RELAY);
@@ -124,7 +124,7 @@ it('runtime format() overrides config tool_format', function (): void {
     $tools = $relay->tools();
 
     expect($tools[0])->toBeInstanceOf(\Laravel\Ai\Contracts\Tool::class);
-});
+})->skip(fn (): bool => ! interface_exists(\Laravel\Ai\Contracts\Tool::class), 'laravel/ai package not installed');
 
 it('extractBaseToolName strips the relay namespace prefix', function (): void {
     $relay = new RelayFake($this->serverName);

--- a/tests/Unit/RelayTest.php
+++ b/tests/Unit/RelayTest.php
@@ -115,7 +115,7 @@ it('returns laravel ai tools when tool_format is aisdk', function (): void {
     $tools = $relay->tools();
 
     expect($tools[0])->toBeInstanceOf(\Laravel\Ai\Contracts\Tool::class);
-})->skip(fn (): bool => ! interface_exists(\Laravel\Ai\Contracts\Tool::class), 'laravel/ai package not installed');
+});
 
 it('runtime format() overrides config tool_format', function (): void {
     config()->set('relay.tool_format', ToolFormat::RELAY);
@@ -124,7 +124,7 @@ it('runtime format() overrides config tool_format', function (): void {
     $tools = $relay->tools();
 
     expect($tools[0])->toBeInstanceOf(\Laravel\Ai\Contracts\Tool::class);
-})->skip(fn (): bool => ! interface_exists(\Laravel\Ai\Contracts\Tool::class), 'laravel/ai package not installed');
+});
 
 it('extractBaseToolName strips the relay namespace prefix', function (): void {
     $relay = new RelayFake($this->serverName);

--- a/tests/Unit/RelayTest.php
+++ b/tests/Unit/RelayTest.php
@@ -126,6 +126,26 @@ it('runtime format() overrides config tool_format', function (): void {
     expect($tools[0])->toBeInstanceOf(\Laravel\Ai\Contracts\Tool::class);
 });
 
+it('extractBaseToolName strips the relay namespace prefix', function (): void {
+    $relay = new RelayFake($this->serverName);
+
+    expect($relay->extractBaseToolNamePublic("relay__{$this->serverName}__test_tool"))
+        ->toBe('test_tool');
+});
+
+it('extractBaseToolName handles tool names that contain double underscores', function (): void {
+    $relay = new RelayFake($this->serverName);
+
+    expect($relay->extractBaseToolNamePublic("relay__{$this->serverName}__my__complex__tool"))
+        ->toBe('my__complex__tool');
+});
+
+it('extractBaseToolName passes through names that do not match the prefix', function (): void {
+    $relay = new RelayFake($this->serverName);
+
+    expect($relay->extractBaseToolNamePublic('plain_tool_name'))->toBe('plain_tool_name');
+});
+
 it('supports mapping any of schemas', function (): void {
     $relay = new RelayFake($this->serverName);
     $tools = $relay->tools();

--- a/tests/Unit/RelayTest.php
+++ b/tests/Unit/RelayTest.php
@@ -7,19 +7,17 @@ namespace Tests\Unit;
 use Illuminate\Support\Facades\Cache;
 use Prism\Prism\Schema\AnyOfSchema;
 use Prism\Prism\Tool;
+use Prism\Relay\Enums\ToolFormat;
 use Prism\Relay\Exceptions\ServerConfigurationException;
 use Prism\Relay\Exceptions\ToolDefinitionException;
 use Tests\TestDoubles\RelayFake;
 
 beforeEach(function (): void {
-    // We'll use the RelayFake for all tests to control its behavior
     $this->serverName = 'test_server';
     config()->set('relay.servers.'.$this->serverName, [
         'url' => 'http://example.com/api',
         'timeout' => 30,
     ]);
-
-    // Clear any cached tools
     Cache::forget('relay-tools-definitions-'.$this->serverName);
 });
 
@@ -46,47 +44,30 @@ it('fetches tool definitions', function (): void {
 });
 
 it('supports caching configuration', function (): void {
-    // Just verify the config is read properly
-
-    // Set a non-zero cache duration
-    config()->set('relay.cache_duration', 60); // 60 minutes
+    config()->set('relay.cache_duration', 60);
 
     $relay = new RelayFake($this->serverName);
-
-    // Call tools() to run the code path
     $relay->tools();
 
-    // This is a very basic test just to ensure the cache-related code exists
-    // and executes without error
     expect(config('relay.cache_duration'))->toBe(60);
 });
 
 it('supports disabling cache with cache_duration=0', function (): void {
-    // Set cache duration to 0 to disable caching
     config()->set('relay.cache_duration', 0);
 
-    $relay = new RelayFake($this->serverName);
-
-    // Cache key based on server name
     $cacheKey = "relay-tools-definitions-{$this->serverName}";
-
-    // Clear any existing cache
     Cache::forget($cacheKey);
 
-    // Call tools to make sure it runs through the code path
+    $relay = new RelayFake($this->serverName);
     $relay->tools();
 
-    // Verify cache doesn't contain the key (since duration is 0)
     expect(Cache::has($cacheKey))->toBeFalse();
 });
 
 it('creates different tool handlers based on inputSchema', function (): void {
     $relay = new RelayFake($this->serverName);
-
-    // Call tools() to create handlers
     $tools = $relay->tools();
 
-    // Test we have the tools we expect
     expect($tools)->toHaveCount(7);
 });
 
@@ -94,8 +75,7 @@ it('handles different parameter types correctly in tools', function (): void {
     $relay = new RelayFake($this->serverName);
     $tools = $relay->tools();
 
-    // The RelayFake already implements test handlers that we can verify
-    expect(count($tools))->toBeGreaterThan(0);
+    expect($tools)->not->toBeEmpty();
 });
 
 it('throws exception when tool definition fetch fails', function (): void {
@@ -109,17 +89,14 @@ it('throws exception when tool definition fetch fails', function (): void {
 it('handles invalid tool definitions', function (): void {
     $relay = new RelayFake($this->serverName);
 
-    // Set invalid tool definitions
     $relay->setToolDefinitions([
         ['description' => 'Missing name'],
-        [], // Empty definition
+        [],
     ]);
 
     $tools = $relay->tools();
-    expect($tools)->toBeArray();
+    expect($tools)->toBeArray()->toBeEmpty();
 
-    // The fake probably auto-adds tools, so just check for expected behavior
-    // when a mix of valid and invalid tools is provided
     $relay->setToolDefinitions([
         ['name' => 'valid_tool', 'description' => 'A valid tool'],
         ['description' => 'Missing name'],
@@ -127,13 +104,30 @@ it('handles invalid tool definitions', function (): void {
 
     $tools = $relay->tools();
     expect($tools)->toBeArray()
-        ->and($tools !== [])->toBeTrue();
+        ->not->toBeEmpty()
+        ->toHaveCount(1);
+});
+
+it('returns laravel ai tools when tool_format is aisdk', function (): void {
+    config()->set('relay.tool_format', ToolFormat::AI_SDK);
+
+    $relay = new RelayFake($this->serverName);
+    $tools = $relay->tools();
+
+    expect($tools[0])->toBeInstanceOf(\Laravel\Ai\Contracts\Tool::class);
+});
+
+it('runtime format() overrides config tool_format', function (): void {
+    config()->set('relay.tool_format', ToolFormat::RELAY);
+
+    $relay = (new RelayFake($this->serverName))->format(ToolFormat::AI_SDK);
+    $tools = $relay->tools();
+
+    expect($tools[0])->toBeInstanceOf(\Laravel\Ai\Contracts\Tool::class);
 });
 
 it('supports mapping any of schemas', function (): void {
     $relay = new RelayFake($this->serverName);
-
-    // Call tools() to create handlers
     $tools = $relay->tools();
 
     $tool = $tools[6];


### PR DESCRIPTION
Relay currently only returns Prism `Tool` objects, making it incompatible with apps built on the Laravel AI SDK. This adds a `ToolFormat::AI_SDK` option so `Relay::tools()` can return `Laravel\Ai\Contracts\Tool\` instances.

### Usage

```php
// Globally via config or env var (RELAY_TOOL_FORMAT=aisdk)
'tool_format' => ToolFormat::AI_SDK,

// Per-call override
$tools = Relay::make('puppeteer')->format(ToolFormat::AI_SDK)->tools();
```

### Breaking Changes

**PHP 8.4 and Laravel 12 are now required** (previously PHP 8.2+ / Laravel 11+).

The `laravel/ai` package, a first-party Laravel package included in Laravel 12, requires PHP 8.4. This PR promotes `laravel/ai` as a hard dependency, providing the `Tool` contract and `illuminate/json-schema` types used in its type signatures. Therefore, Relay’s minimum requirements must align with it. Supporting Laravel 11 or PHP < 8.4 with a hard `laravel/ai` dependency is complex and not feasible.
