### PR TITLE
fix: map JSON Schema enums to EnumSchema

### DIFF
--- a/src/Relay.php
+++ b/src/Relay.php
@@ -376,6 +376,12 @@ class Relay
             return new AnyOfSchema($itemsSchema, $name, $description);
         }
 
+        $options = data_get($property, 'enum');
+
+        if (is_array($options) && $options !== [] && $this->isEnumOptions($options)) {
+            return new EnumSchema($name, $description, array_values($options));
+        }
+
         $itemsSchema = $this->getSchemeParameter('', data_get($property, 'items', []), $definitionName);
 
         return match ($type) {
@@ -387,6 +393,23 @@ class Relay
             'array' => $itemsSchema instanceof Schema ? new ArraySchema($name, $description, $itemsSchema) : null,
             default => null,
         };
+    }
+
+    /**
+     * EnumSchema resolves its own type from the options, so anything it cannot
+     * type has to fall through to the regular resolution.
+     *
+     * @param  array<int|string, mixed>  $options
+     */
+    protected function isEnumOptions(array $options): bool
+    {
+        foreach ($options as $option) {
+            if (! is_string($option) && ! is_int($option) && ! is_float($option)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/TestDoubles/RelayFake.php
+++ b/tests/TestDoubles/RelayFake.php
@@ -206,6 +206,29 @@ class RelayFake extends Relay
                     'required' => ['nameOrId'],
                 ],
             ],
+            [
+                'name' => 'enum_tool',
+                'description' => 'A tool with enum parameters',
+                'inputSchema' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'status' => [
+                            'type' => 'string',
+                            'description' => 'The status to filter on',
+                            'enum' => ['open', 'closed'],
+                        ],
+                        'categories' => [
+                            'type' => 'array',
+                            'description' => 'The categories to filter on',
+                            'items' => [
+                                'type' => 'string',
+                                'enum' => ['news', 'sport'],
+                            ],
+                        ],
+                    ],
+                    'required' => ['status'],
+                ],
+            ],
         ];
     }
 

--- a/tests/Unit/RelayTest.php
+++ b/tests/Unit/RelayTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit;
 
 use Illuminate\Support\Facades\Cache;
 use Prism\Prism\Schema\AnyOfSchema;
+use Prism\Prism\Schema\ArraySchema;
+use Prism\Prism\Schema\EnumSchema;
 use Prism\Prism\Tool;
 use Prism\Relay\Exceptions\ServerConfigurationException;
 use Prism\Relay\Exceptions\ToolDefinitionException;
@@ -87,7 +89,7 @@ it('creates different tool handlers based on inputSchema', function (): void {
     $tools = $relay->tools();
 
     // Test we have the tools we expect
-    expect($tools)->toHaveCount(7);
+    expect($tools)->toHaveCount(8);
 });
 
 it('handles different parameter types correctly in tools', function (): void {
@@ -154,4 +156,32 @@ it('supports mapping any of schemas', function (): void {
             ],
             'description' => 'Parameter nameOrId for union_tool',
         ]);
+});
+
+it('maps json schema enums to enum schemas', function (): void {
+    $relay = new RelayFake($this->serverName);
+
+    $tool = $relay->tools()[7];
+    $status = $tool->parameters()['status'];
+
+    expect($status)
+        ->toBeInstanceOf(EnumSchema::class)
+        ->and($status->toArray())->toBe([
+            'description' => 'The status to filter on',
+            'enum' => ['open', 'closed'],
+            'type' => 'string',
+        ]);
+});
+
+it('maps json schema enums nested in array items', function (): void {
+    $relay = new RelayFake($this->serverName);
+
+    $tool = $relay->tools()[7];
+    $categories = $tool->parameters()['categories'];
+
+    expect($categories)
+        ->toBeInstanceOf(ArraySchema::class)
+        ->and($categories->items)
+        ->toBeInstanceOf(EnumSchema::class)
+        ->and($categories->items->options)->toBe(['news', 'sport']);
 });


### PR DESCRIPTION
Fixes #38.

`getSchemeParameter()` resolved a property by matching on `type` alone, so a standard JSON Schema enum (`{"type": "string", "enum": [...]}`) became a plain `StringSchema` and the allowed values never reached the model. The existing `'enum'` branch expects `{"type": "enum", "options": [...]}`, which is not JSON Schema and which no MCP server emits, so it was unreachable.

This resolves the `enum` keyword before the type based matching:

```php
$options = data_get($property, 'enum');

if (is_array($options) && $options !== [] && $this->isEnumOptions($options)) {
    return new EnumSchema($name, $description, array_values($options));
}
```

Because the method recurses through `$this` for `items`, enums nested inside arrays are covered as well, without extra handling.

`isEnumOptions()` guards the case Prism cannot type: `EnumSchema` derives its own type from the options and only handles strings and numbers, so anything else falls through to the existing resolution rather than blowing up.

The old `'enum'` branch is left untouched, so nothing that relied on it changes.

### Tests

Added an `enum_tool` fixture to `RelayFake` and two cases to `RelayTest`: a string enum and an enum nested in array items. Full suite passes (90 tests), Pint and PHPStan are clean.
